### PR TITLE
fix(#115): Scope gitignore data/ pattern to root only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@ dist/
 .idea/
 
 # Project Specific
-data/
+/data/
 *.log
 backend/mineopt_pro.db
 *.db


### PR DESCRIPTION
## Problem
The root `.gitignore` had `data/` which matches **any** directory named `data` anywhere in the repo, blocking files in `frontend/src/components/data/` from being tracked.

## Fix
Changed `data/` → `/data/` so only the root-level `data/` directory is ignored.

Closes #115